### PR TITLE
Fix podTemplate format

### DIFF
--- a/vars/gradleTemplate.groovy
+++ b/vars/gradleTemplate.groovy
@@ -12,10 +12,12 @@ def call(Map parameters = [:], body) {
 
     podTemplate(label: label, inheritFrom: "${inheritFrom}",
             containers: [
-                [name: 'gradle', image: "${gradleImage}", command: '/bin/sh -c', args: 'cat', ttyEnabled: true],
-                [name: 'docker', image: "${dockerImage}", command: '/bin/sh -c', args: 'cat', ttyEnabled: true]],
+                containerTemplate(name: 'gradle', image: "${gradleImage}", command: '/bin/sh -c', args: 'cat', ttyEnabled: true),
+                containerTemplate(name: 'docker', image: "${dockerImage}", command: '/bin/sh -c', args: 'cat', ttyEnabled: true)],
             volumes: [hostPathVolume(hostPath: '/var/run/docker.sock', mountPath: '/var/run/docker.sock')],
-            envVars: [[key: 'DOCKER_HOST', value: 'unix:/var/run/docker.sock'], [key: 'DOCKER_CONFIG', value: '/home/jenkins/.docker/']]
+            envVars: [
+                envVar(key: 'DOCKER_HOST', value: 'unix:///var/run/docker.sock'),
+                envVar(key: 'DOCKER_CONFIG', value: '/home/jenkins/.docker/')]
     ) {
         body()
     }

--- a/vars/mavenTemplate.groovy
+++ b/vars/mavenTemplate.groovy
@@ -12,11 +12,13 @@ def call(Map parameters = [:], body) {
 
     podTemplate(label: label, inheritFrom: "${inheritFrom}",
             containers: [
-                [name: 'maven', image: "${mavenImage}", command: '/bin/sh -c', args: 'cat', ttyEnabled: true, envVars: [ [key: 'MAVEN_OPTS', value: '-Duser.home=/root/'] ]],
-                [name: 'docker', image: "${dockerImage}", command: '/bin/sh -c', args: 'cat', ttyEnabled: true]],
+                containerTemplate(name: 'maven', image: "${mavenImage}", command: '/bin/sh -c', args: 'cat', ttyEnabled: true, envVars: [ envVar(key: 'MAVEN_OPTS', value: '-Duser.home=/root/') ]),
+                containerTemplate(name: 'docker', image: "${dockerImage}", command: '/bin/sh -c', args: 'cat', ttyEnabled: true)],
             volumes: [configMapVolume(configMapName: 'jenkins-maven-settings', mountPath: '/root/.m2'),
                       hostPathVolume(hostPath: '/var/run/docker.sock', mountPath: '/var/run/docker.sock')],
-            envVars: [[key: 'DOCKER_HOST', value: 'unix:/var/run/docker.sock'], [key: 'DOCKER_CONFIG', value: '/home/jenkins/.docker/']]
+            envVars: [
+                envVar(key: 'DOCKER_HOST', value: 'unix:///var/run/docker.sock'),
+                envVar(key: 'DOCKER_CONFIG', value: '/home/jenkins/.docker/')]
     ) {
 
         body(

--- a/vars/nodejsTemplate.groovy
+++ b/vars/nodejsTemplate.groovy
@@ -12,10 +12,13 @@ def call(Map parameters = [:], body) {
 
 	podTemplate(label: label, inheritFrom: "${inheritFrom}",
 			containers: [
-					[name: 'docker', image: "${dockerImage}", command: 'cat', ttyEnabled: true, privileged: true],
-					[name: 'nodejs', image: "${nodejsImage}", command: '/bin/sh -c', args: 'cat', ttyEnabled: true,  workingDir: '/home/jenkins/']],
+					containerTemplate(name: 'docker', image: "${dockerImage}", command: 'cat', ttyEnabled: true, privileged: true),
+					containerTemplate(name: 'nodejs', image: "${nodejsImage}", command: '/bin/sh -c', args: 'cat', ttyEnabled: true,  workingDir: '/home/jenkins/')],
 			volumes: [hostPathVolume(hostPath: '/var/run/docker.sock', mountPath: '/var/run/docker.sock')],
-			envVars: [[key: 'DOCKER_HOST', value: 'unix:/var/run/docker.sock'], [key: 'DOCKER_CONFIG', value: '/home/jenkins/.docker/']]) {
+			envVars: [
+                envVar(key: 'DOCKER_HOST', value: 'unix:///var/run/docker.sock'),
+                envVar(key: 'DOCKER_CONFIG', value: '/home/jenkins/.docker/')]
+    ) {
 		body()
 	}
 }


### PR DESCRIPTION
The latest version of jenkins + libraries require the class to be specified which is done with these helper functions. The docker path format was also incorrect (not sure how it was working before to be honest).

I have tested the mavenTemplate and gradleTemplate successfully.