### PR TITLE
Remove --recreate-pods so rolling updates work

### DIFF
--- a/vars/helmDeploy.groovy
+++ b/vars/helmDeploy.groovy
@@ -9,6 +9,6 @@ def call(config) {
     container('helm') {
         sh "helm init --client-only"
         sh "helm repo add sprinthive-service-dev-charts https://sprinthive-service-dev-charts.storage.googleapis.com/"
-        sh "helm upgrade ${config.releaseName} --namespace ${config.namespace} -i --reset-values --recreate-pods --wait sprinthive-service-dev-charts/${config.chartName} --set image.tag=${config.imageTag} ${overrides}"
+        sh "helm upgrade ${config.releaseName} --namespace ${config.namespace} -i --reset-values --wait sprinthive-service-dev-charts/${config.chartName} --set image.tag=${config.imageTag} ${overrides}"
     }
 }


### PR DESCRIPTION
The --recreate-pods flag is destroying all pods which defeats the point of a rolling update.
The flag was originally added to ensure the latest version was always used as in some cases the pod will not be torn down (I think this is the case for statefulsets). We will tackle that problem when we get there.