### PR TITLE
Jacoco reports with enabled flag

### DIFF
--- a/vars/standardJavaDeploy.groovy
+++ b/vars/standardJavaDeploy.groovy
@@ -31,7 +31,7 @@ def call(config) {
 
         stage('Unit test') {
             container(name: config.buildContainerOverride != null ? config.buildContainerOverride : 'gradle') {
-                def testCommand = config.buildCommandOverride != null ? config.buildCommandOverride : "gradle test"
+                def testCommand = config.buildCommandOverride != null ? config.buildCommandOverride : "gradle test jacocoTestReport"
                 sh """
                     export ENV_STAGE=${envInfo.deployStage}
                     export ENV_BRANCH=${envInfo.branch}

--- a/vars/standardJavaDeploy.groovy
+++ b/vars/standardJavaDeploy.groovy
@@ -40,6 +40,10 @@ def call(config) {
             }
         }
 
+        stage('JaCoCo') {
+            jacoco exclusionPattern: '**/*Test.class', inclusionPattern: '**/*.class', sourceExclusionPattern: 'generated/**/*.java,generated/**/*.kt', sourceInclusionPattern: '**/*.java,**/*.kt', sourcePattern: '**/src/main/java,**/src/main/kotlin'
+        }
+
         stage('Build docker image') {
             container('docker') {
                 sh "docker build -t ${dockerImage} --build-arg SOURCE_VERSION=${scmInfo.GIT_COMMIT} ."

--- a/vars/standardJavaDeploy.groovy
+++ b/vars/standardJavaDeploy.groovy
@@ -46,19 +46,13 @@ def call(config) {
                     ${testCommand}
                 """
             }
-
-            if (config.jacocoEnabled) {
-                step {
-                    jacoco exclusionPattern: '**/*Test.class', inclusionPattern: '**/*.class', sourceExclusionPattern: 'generated/**/*.java,generated/**/*.kt', sourceInclusionPattern: '**/*.java,**/*.kt', sourcePattern: '**/src/main/java,**/src/main/kotlin'
-                }
-            }
         }
 
-//        if (config.jacocoEnabled) {
-//            stage('JaCoCo') {
-//                jacoco exclusionPattern: '**/*Test.class', inclusionPattern: '**/*.class', sourceExclusionPattern: 'generated/**/*.java,generated/**/*.kt', sourceInclusionPattern: '**/*.java,**/*.kt', sourcePattern: '**/src/main/java,**/src/main/kotlin'
-//            }
-//        }
+        if (config.jacocoEnabled) {
+            stage('JaCoCo') {
+                jacoco exclusionPattern: '**/*Test.class', inclusionPattern: '**/*.class', sourceExclusionPattern: 'generated/**/*.java,generated/**/*.kt', sourceInclusionPattern: '**/*.java,**/*.kt', sourcePattern: '**/src/main/java,**/src/main/kotlin'
+            }
+        }
 
         stage('Build docker image') {
             container('docker') {


### PR DESCRIPTION
Generation of JaCoCo reports with `jacocoEnabled` config flag to enable/disable.
This feature depends on the JaCoCo plugin to be installed in Jenkins.