### PR TITLE
Add flag for republishDeployPipeline to skip Helm Deploy stage.

### DIFF
--- a/vars/republishDeployPipeline.groovy
+++ b/vars/republishDeployPipeline.groovy
@@ -11,6 +11,7 @@
  * @param config.chartRepoOverride: (Optional) Override the helm chart repo used to fetch the helm chart
  * @param config.requireReleaseApproval: (Optional) Request approval before releasing into the environment
  * @param config.nextStageName: The environment stage name that will be deployed into
+ * @param config.skipDeploy: Deployment will skip Helm Deploy stage
  * @return
  */
 def call(config) {
@@ -36,14 +37,16 @@ def call(config) {
       }
     }
 
-    for (namespace in config.namespaces) {
-      stage("Helm Deploy: $namespace") {
-        helmDeploy([
-                releaseName      : config.application,
-                namespace        : namespace,
-                chartName        : config.chartNameOverride != null ? config.chartNameOverride : config.application,
-                imageTag         : params.imageTag
-        ])
+    if (config.skipDeploy != true) {
+      for (namespace in config.namespaces) {
+        stage("Helm Deploy: $namespace") {
+          helmDeploy([
+                  releaseName      : config.application,
+                  namespace        : namespace,
+                  chartName        : config.chartNameOverride != null ? config.chartNameOverride : config.application,
+                  imageTag         : params.imageTag
+          ])
+        }
       }
     }
   }

--- a/vars/republishDeployPipeline.groovy
+++ b/vars/republishDeployPipeline.groovy
@@ -2,7 +2,7 @@
 
 /**
  * @param config.application: The application being deployed
- * @param config.namespace: The kubernetes namespace into which the application should be deployed
+ * @param config.namespace: (Optional) if skipDeploy is true. The kubernetes namespace into which the application should be deployed.
  * @param config.gcrCredentialsId: The credentials id for a GCR Service Account that can read from the source GCR \
  *        repository and publish to the target GCR repository
  * @param config.sourceGcrProjectId: The GCP project id of the project with the source GCR repository

--- a/vars/republishDeployPipeline.groovy
+++ b/vars/republishDeployPipeline.groovy
@@ -11,7 +11,7 @@
  * @param config.chartRepoOverride: (Optional) Override the helm chart repo used to fetch the helm chart
  * @param config.requireReleaseApproval: (Optional) Request approval before releasing into the environment
  * @param config.nextStageName: The environment stage name that will be deployed into
- * @param config.skipDeploy: Deployment will skip Helm Deploy stage
+ * @param config.skipDeploy: (Optional) Deployment will skip Helm Deploy stage
  * @return
  */
 def call(config) {


### PR DESCRIPTION
# Description
This change adds an override to allow republishing of docker tags without running helm deploy stage.

 ```if (config.skipDeploy != true) {```