### PR TITLE
Upgrades the version of node from 12 to 16

### DIFF
--- a/vars/nodejsTemplate.groovy
+++ b/vars/nodejsTemplate.groovy
@@ -3,7 +3,7 @@ def call(Map parameters = [:], body) {
     def defaultLabel = buildId('nodejs')
     def label = parameters.get('label', defaultLabel)
 
-    def nodejsImage = parameters.get('nodejsImage', 'node:12-alpine')
+    def nodejsImage = parameters.get('nodejsImage', 'node:16-alpine')
     def dockerImage = parameters.get('dockerImage', 'docker:19.03.8')
     def clairScannerImage = parameters.get('clairScannerImage', 'objectiflibre/clair-scanner:latest')
     def helmImage = parameters.get('helmImage', 'quay.io/roboll/helmfile:v0.138.7')


### PR DESCRIPTION
Jenkins build is currently failing with the following message:
error react-scripts@5.0.0: The engine "node" is incompatible with this module. Expected version ">=14.0.0". Got "12.22.10"