### PR TITLE
Add nodeAppVersion to include Release version in Node Tags

### DIFF
--- a/vars/nodeAppVersion.groovy
+++ b/vars/nodeAppVersion.groovy
@@ -1,0 +1,3 @@
+def call() {
+    return sh(script: "node -p 'require(\"./client/package.json\").version'", returnStdout: true).toString().trim()
+}

--- a/vars/standardNodeDeploy.groovy
+++ b/vars/standardNodeDeploy.groovy
@@ -9,16 +9,11 @@ def call(config) {
         def scmInfo = checkout scm
         def envInfo = environmentInfo(scmInfo)
         targetNamespace = envInfo.deployStage
-        if (config.subModuleName != null) {
-            contextDirectory = "${env.WORKSPACE}/${config.subModuleName}"
-        } else {
-            contextDirectory = env.WORKSPACE
-        }
         echo "Current branch is: ${envInfo.branch}"
         echo "Deploy namespace is: ${envInfo.deployStage}"
-        echo "Context directory is: ${contextDirectory}"
-        versionTag = "${getNewVersion{}}"
+        echo "Context directory is: ${env.WORKSPACE}"
         stage('Build distribution') {
+            versionTag = getNewVersion{}
             container(name: "nodejs") {
                 versionTag = "${nodeAppVersion()}-${versionTag}"
                 def buildCommand = config.buildCommandOverride != null ? config.buildCommandOverride : "yarn && yarn install --production"

--- a/vars/standardNodeDeploy.groovy
+++ b/vars/standardNodeDeploy.groovy
@@ -9,13 +9,18 @@ def call(config) {
         def scmInfo = checkout scm
         def envInfo = environmentInfo(scmInfo)
         targetNamespace = envInfo.deployStage
+        if (config.subModuleName != null) {
+            contextDirectory = "${env.WORKSPACE}/${config.subModuleName}"
+        } else {
+            contextDirectory = env.WORKSPACE
+        }
         echo "Current branch is: ${envInfo.branch}"
         echo "Deploy namespace is: ${envInfo.deployStage}"
-
+        echo "Context directory is: ${contextDirectory}"
+        versionTag = "${getNewVersion{}}"
         stage('Build distribution') {
-            versionTag = getNewVersion{}
-
             container(name: "nodejs") {
+                versionTag = "${nodeAppVersion()}-${versionTag}"
                 def buildCommand = config.buildCommandOverride != null ? config.buildCommandOverride : "yarn && yarn install --production"
                 sh """
                     export ENV_STAGE=${envInfo.deployStage}


### PR DESCRIPTION
This change is to include the version of a node application in its image tag.

Test build with SprintHive Console in Dev using my branch: https://jenkins.qa00.sprinthive.tech/job/SprintHive/job/dev/job/build/job/sprinthive-console-v1/125/

Ends up with the image tag of: `eu.gcr.io/sh-honeycomb/sprinthive-console:2.2.9-c9cc6e7`