### PR TITLE
Fix Quotes in change log breaking promotions

### DIFF
--- a/vars/deployRemotePromotePipeline.groovy
+++ b/vars/deployRemotePromotePipeline.groovy
@@ -44,7 +44,7 @@ def call(config) {
 
   stage("Trigger ${config.promotionStageName} Pipeline") {
     withCredentials([string(credentialsId: config.remoteTriggerCredentials, variable: 'token')]) {
-      httpRequest contentType: 'APPLICATION_JSON', customHeaders: [[maskValue: true, name: 'Authorization', value: "Bearer ${token}"]], httpMode: 'POST', requestBody: "{\"triggerJob\": \"${config.remoteJob}\", \"imageTag\": \"${params.imageTag}\", \"sourceBuildNumber\": \"${env.BUILD_NUMBER}\", \"changeLog\": \"${params.changeLog}\"}", responseHandle: 'NONE', url: "https://${config.remoteHostName}/generic-webhook-trigger/invoke"
+      httpRequest contentType: 'APPLICATION_JSON', customHeaders: [[maskValue: true, name: 'Authorization', value: "Bearer ${token}"]], httpMode: 'POST', requestBody: "{\"triggerJob\": \"${config.remoteJob}\", \"imageTag\": \"${params.imageTag}\", \"sourceBuildNumber\": \"${env.BUILD_NUMBER}\", \"changeLog\": \"${params.changeLog.replaceAll('"', '\\\\"')}\"}", responseHandle: 'NONE', url: "https://${config.remoteHostName}/generic-webhook-trigger/invoke"
     }
   }
 }


### PR DESCRIPTION
A promotion from QA to Prod failed due to the change log containing quotes (due to a reverted git change)

Failed promotion:
https://app.mezmo.com/bccdc66390/logs/view?t=timestamp%3A1724746378097&a=1724746378097.1781515434651250688&q=app%3Ajenkins

Successful test using this branch:
QA Job:
https://jenkins.qa00.sprinthive.tech/job/SprintHive/job/qa/job/deploy/job/income-v1/351/

Prod Job created via promotion (with the same changelog):
https://jenkins.prod00.sprinthive.tech/job/SprintHive/job/prod/job/deploy/job/income-v1/798/
