### PR TITLE
Allow arm nodes to tolerate sh-services purpose

### DIFF
--- a/vars/ciNode.groovy
+++ b/vars/ciNode.groovy
@@ -17,6 +17,10 @@ def call(Map parameters = [:], body) {
           operator: Equal
           value: "arm64"
           effect: NoSchedule
+        - key: sprinthive.com/purpose
+          operator: Equal
+          value: "sh-services"
+          effect: NoSchedule
     """
     def armNodeSelector = """
         sprinthive.com/instance-type: "c4a"


### PR DESCRIPTION
ARM services can not presently build in DA due to the ARM node-pool being tainted. This was an oversight of the change added in https://bitbucket.org/sprinthive/infrastructure/pull-requests/1560